### PR TITLE
A refreshed thread starts with an empty echo table, like the resume it says it is

### DIFF
--- a/openreynolds/loop.py
+++ b/openreynolds/loop.py
@@ -388,9 +388,7 @@ class Loop:
             "carry forward can go on disk now; the next message starts a fresh thread."
         )
         self.run()
-        self.messages = []
-        self.context_tokens = 0
-        self.brief(blurb)
+        self.restart(blurb)
 
     def settle(self) -> None:
         """Answer any tool call left dangling by an interrupted turn.
@@ -421,9 +419,21 @@ class Loop:
         )
 
     def restart(self, blurb: str) -> None:
-        """Begin a fresh thread from a factual situation blurb."""
+        """Begin a fresh thread from a factual situation blurb.
+
+        Everything the old thread carried goes here, and `ctx.echoes` is part of what
+        it carried. The echo table maps a digest to the call whose bytes are still in
+        the conversation, and it is the one piece of thread state that does not live
+        on the thread: `ToolContext` is built once a session and never replaced. Left
+        standing, every digest recorded before the reset stays matchable after it, so
+        the first thing a freshly briefed model does -- go back and read the solver
+        log it no longer remembers -- is answered with a pointer to a call that is no
+        longer in any conversation, and asking again returns the same pointer for the
+        rest of the session.
+        """
         self.messages = []
         self.context_tokens = 0
+        self.ctx.echoes.clear()
         self.brief(blurb)
 
     # -- capture ---------------------------------------------------------------

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -146,6 +146,60 @@ def test_refresh_warns_the_model_then_starts_a_fresh_thread(loop):
     assert "study s1" in loop.messages[0]["content"]
 
 
+def tool_result(loop, tool_use_id: str) -> str:
+    """What went back for one tool call, wherever in the thread it ended up."""
+    for msg in loop.messages:
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if isinstance(block, dict) and block.get("tool_use_id") == tool_use_id:
+                return block["content"]
+    raise AssertionError(f"no tool result for {tool_use_id}")
+
+
+@pytest.fixture
+def roomy_loop(backend, store, view):
+    """A loop whose output cap is above the echo threshold, so a large repeat is
+    actually large by the time it is compared."""
+    ctx = ToolContext(backend=backend, store=store, max_output=50_000)
+    return Loop(Config(llm_api_key="test-key", model="claude-opus-5"), ctx, store, view)
+
+
+def test_a_repeat_after_a_refresh_gets_the_bytes_and_not_a_pointer(roomy_loop, backend):
+    """The echo pointer says the bytes are still in this conversation. A refresh
+    empties the conversation, and `ctx.echoes` outlived it -- so a study long enough
+    to refresh, which is any study worth running, answered the model's first re-read
+    on the far side with a reference to a call that was no longer there. It never
+    recovered: asking again matched the same stale digest."""
+    log = "Solving for Ux, Initial residual = 1e-04\n" * 140   # ~5.6 KB
+    backend.files["/work/log.simpleFoam"] = log.encode()
+    read = {"path": "/work/log.simpleFoam"}
+
+    install(roomy_loop, [
+        message([tool_block("read_file", read, "tu1")], stop_reason="tool_use"),
+        message([text_block("read it")]),
+        message([text_block("noted")]),          # the turn refresh() runs before resetting
+        message([tool_block("read_file", read, "tu2")], stop_reason="tool_use"),
+        message([text_block("read it again")]),
+    ])
+
+    roomy_loop.say("read the log")
+    roomy_loop.run()
+    assert log in tool_result(roomy_loop, "tu1")
+
+    roomy_loop.refresh("study s1 on instance i1. Jobs still running: none.")
+
+    roomy_loop.say("read the log again")
+    roomy_loop.run()
+    again = tool_result(roomy_loop, "tu2")
+
+    assert "identical, byte for byte" not in again, (
+        "the thread that pointer indexes into was emptied by the refresh"
+    )
+    assert log in again
+
+
 def test_every_turn_is_mirrored_locally(loop, store):
     install(
         loop,


### PR DESCRIPTION
Closes #23.

`_echo` answers a byte-identical repeat with a pointer at the call that first returned
those bytes, and tells the model they are still in this conversation. `ctx.echoes` is
the one piece of thread state that does not live on the thread — `ToolContext` is built
once a session at `cli.py:968` and never replaced — so every digest recorded before
`refresh()` stayed matchable after it, naming a call that had just been thrown away.
The moment it fires is the bad one: the first thing a freshly briefed model does is go
back and read the solver log it no longer remembers, and that read came back as a
reference to nothing, for the rest of the session. #23 has the full trace.

## What is now true

A reset thread starts with an empty echo table, so a repeat after a refresh is answered
with the bytes.

`refresh()` does what its docstring already claimed — *"the same move a resume makes"* —
and routes through `restart()`. `restart()` was written for exactly this and had no
callers in the package; it now has one, and there is a single reset path rather than two
that have to be kept in step. That is what stops a third one drifting: the bug was not
the missing `clear()` so much as the duplicated reset.

## The test

`test_a_repeat_after_a_refresh_gets_the_bytes_and_not_a_pointer`, in `tests/test_loop.py`
beside the existing refresh test. It drives the real `Loop.refresh()` against the existing
fixtures — no workspace, no network — and reads the tool result by `tool_use_id` rather
than by index, because the brief that follows a refresh moves everything along.

With the `clear()` removed it fails on the line that matters:

```
E       AssertionError: the thread that pointer indexes into was emptied by the refresh
E       assert 'identical, byte for byte' not in '[identical,...5740 of 5740'
```

Suite is green on this branch, one test up on `main`.

## Notes

- No entry in `docs/found-by-using-it.md`. That file is *what running it found*, and this
  came out of reading `refresh()` next to `_echo`, not out of a session going wrong. It
  would be the first entry there that a green suite did not survive by luck of nobody
  looking — happy to add one if you would rather the casebook cover both.
- If `Loop` reaching into `ctx` is the wrong shape, the other way is a thread generation
  counter that `refresh()` increments and `_echo` keys on, so a stale digest can never
  match. That is a bigger change for the same guarantee; this one is two lines.

---

@ka-bear — this is the fix for #23. Two lines of behaviour change; the rest is the
test and the docstring. Happy to reshape it if the `restart()` route is not the one you
want.
