### PR TITLE
Two named levels: how far a study goes, and when it comes back to ask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ All notable changes to this project are recorded here. The format follows
 
 ### Added
 
+- **Two named levels: `ambition` and `consent`** (`openreynolds/levels.py`, issue #25).
+  How much work a study is worth and when to come back and ask are separate things, and
+  until now there was one control over both: `preferences.md`, free text, empty by
+  default. Empty is not neutral -- it is the ambitious end, picked by default and
+  discovered afterwards, and a modest question could become a refinement family with
+  transient runs and animation frames before anyone was asked. `ambition` is
+  `sketch | standard | thorough` and `consent` is `early | costly | never`, three levels
+  each and defaults (`standard`, `costly`) that are written down rather than implied.
+  Separate axes, so "thorough, but check with me before real money" and "just the quick
+  version, don't ask" are each one line. Three scopes: `openreynolds config` and
+  `OPENREYNOLDS_AMBITION`/`OPENREYNOLDS_CONSENT` for the usual pair, `--ambition` and
+  `--consent` for a session, and `/level thorough never` for a change mid-study when the
+  answer turns out to be more interesting than the question. `/level` on its own shows
+  the menu and `/status` reports the pair, neither costing a turn -- which is the whole
+  reason these are named values rather than more prose. A line `/level` cannot wholly
+  use applies none of itself, a typo and a self-contradicting pair (`/level standard
+  thorough`) alike: half of what somebody typed, taken silently, is worse than nothing.
+  They carry intent and not a ceiling: a spend or wall-clock cap the harness checked
+  itself would be the budget `docs/design.md` §1 rules out by name. `preferences.md` is unchanged and still
+  relayed verbatim; where it and a level disagree the briefing says the note wins,
+  because the note is the person's own sentences and the level came off a menu.
+  Every combination of the two goes through `test_briefing.py`'s imperative sweep, so a
+  level says what the person wants and never what the model has to do.
 - The mesh desk (`openreynolds/mesher/`): geometry and meshing are now one small agent
   with one tool. It gets a shape in words and a case directory, and works the way a
   person at a terminal does -- one fenced ```bash block a message, run on the instance
@@ -49,6 +72,14 @@ All notable changes to this project are recorded here. The format follows
   attached to its output as though it had just been drawn.
 - A model call that fails with an overloaded or gateway status is retried once. A desk
   five minutes into a mesh cannot resume; the next call starts a clean thread.
+- **A context refresh no longer forgets what the user asked for.** `Loop.refresh` empties
+  the thread and re-opens it with `watch.situation()`, which describes the workspace and
+  nothing about the person -- so `preferences.md` was relayed once at session start and
+  thrown away at 80% of the window, and the second half of every long study ran without
+  the standing note its first half had. The two new levels would have been lost the same
+  way, with `/status` still reporting them from the config, which is how this was found.
+  The blurb a rebuilt thread opens with now carries both (`cli._fresh_thread_brief`), and
+  it goes through the same imperative sweep the session-start briefing does.
 - A user turn carrying a picture reaches an OpenAI-family model. The provider's renderer
   handled an image inside a tool result and dropped a bare `image` block in a user
   message, which is exactly the shape the mesh desk sends every render in: a model was

--- a/README.md
+++ b/README.md
@@ -121,6 +121,34 @@ own voice from `preferences.md` beside your config. Say you want the mesh render
 checked before any solver time is spent, and that is what the agent is told you want.
 What it does about it is its call.
 
+## How far a study goes, and when you get asked
+
+Those are two different things, and a blank page made you say both at once. They are
+named settings now, and the defaults are written down rather than implied:
+
+| `--ambition` | how much work the study is worth |
+| --- | --- |
+| `sketch` | one mesh, a headline number, and an honest word about what it rests on |
+| `standard` | *(default)* one solid answer to the question as asked, checked as far as that answer needs |
+| `thorough` | mesh independence, transient where the physics wants it, a comparison against published data |
+
+| `--consent` | when to come back and ask |
+| --- | --- |
+| `early` | a word before solver time is spent at all |
+| `costly` | *(default)* a word before anything expensive — a long transient, a large mesh, a family of runs |
+| `never` | no interruptions; a run that goes the whole way and reports at the end |
+
+Separate axes, so `--ambition thorough --consent never` and `--ambition sketch
+--consent early` are both one line. They set intent, not a ceiling: nothing here is a
+budget the agent is stopped against, because the harness stopping the agent is the one
+thing this repository will not do.
+
+`openreynolds config` sets your usual pair, the two flags override them for a session,
+and `/level thorough never` changes them mid-study when the answer turns out to be more
+interesting than the question. `/level` on its own shows the menu without costing a
+turn. Where `preferences.md` and a level disagree, the note wins — you wrote it, the
+levels came off a menu.
+
 ## Bring your own model
 
 The agent calls your provider directly with your key; the workspace service never sees
@@ -213,9 +241,10 @@ costs nothing and a rule that is enforced costs everything.
 | `openreynolds video` | Assemble mirrored frames into a video, here. |
 | `openreynolds stop` | Stop this study's jobs and confirm they stopped. `--force` skips the prompt. |
 
-In a session, `/status` answers locally with no model turn, `/btw` says something
-without interrupting the work, and anything else you type reaches the model at its next
-step, so you can steer a run without stopping it. `/help` has the rest.
+In a session, `/status` answers locally with no model turn, `/level` shows and changes
+how far this study goes, `/btw` says something without interrupting the work, and
+anything else you type reaches the model at its next step, so you can steer a run
+without stopping it. `/help` has the rest.
 
 ## Configuration
 
@@ -231,6 +260,7 @@ containers want:
 | `OPENREYNOLDS_PROVIDER` | A preset name, or `reynolds` for the metered model. |
 | `OPENREYNOLDS_LLM_API_KEY` | The model key. The vendor's own name (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) is read too. |
 | `OPENREYNOLDS_MODEL` / `OPENREYNOLDS_EFFORT` | Which model, and how hard it is asked to think. |
+| `OPENREYNOLDS_AMBITION` / `OPENREYNOLDS_CONSENT` | How far a study goes, and when it comes back to ask. |
 | `FOAMD_URL` / `FOAMD_API_KEY` | The workspace service and this machine's key. |
 | `OPENREYNOLDS_MIRROR_INTERVAL_S` | How often files come home. `0` turns it off. |
 | `OPENREYNOLDS_NARRATE_EVERY_S` | How often a long run wakes the model. `0` turns it off. |

--- a/docs/design.md
+++ b/docs/design.md
@@ -44,6 +44,16 @@ The agent decides everything about how to work. The harness is plumbing. Concret
 
 There is no gate DAG, no state machine, no lock, no watchdog with authority, no budget the model must reason about. If the agent wants to write itself a spec, tests, or a checklist, it can — and nothing verifies that it did.
 
+**What the user says is not a harness rule.** `preferences.md` is relayed verbatim, and
+the two named levels (`ambition`, `consent` — §11) are relayed as what the person picked
+off a menu. Both are facts about what someone wants, in the same class as "a person is
+at the terminal"; neither is checked, enforced or graded, and what to do about either
+stays the model's call. This is why the levels carry intent and not a ceiling: a spend
+or wall-clock cap the harness could check itself would be exactly the budget the
+paragraph above rules out. `test_briefing.py` sweeps every combination of the two
+through the imperative patterns for the same reason it sweeps every other shape of the
+briefing.
+
 These are the constraints the code has today and three tests hold it to them (`test_prompt.py`, `test_briefing.py`, `test_negative_obligation.py`). They are a thesis with evidence behind it (`found-by-using-it.md`), not a law: if a measured result argues for a different division of labour, change the tests together with the code rather than working around them.
 
 ---
@@ -220,9 +230,22 @@ This is the platform-value capture that makes the closed pieces worth building, 
 | `openreynolds --study <id>` | resume (fresh-thread reorientation) |
 | `openreynolds --instance <id>` | reuse an existing instance |
 | `openreynolds studies` | list local sessions |
-| `openreynolds config` | set `FOAMD_API_KEY`, `ANTHROPIC_API_KEY`, base URL, model |
+| `openreynolds config` | set `FOAMD_API_KEY`, `ANTHROPIC_API_KEY`, base URL, model, the two levels |
+| `--ambition sketch\|standard\|thorough` | how much work this study is worth |
+| `--consent early\|costly\|never` | when to come back and ask |
 
 Fetched PNGs print their local paths; inline terminal image display (iTerm2/kitty protocols) is an A5 nicety.
+
+**Ambition and consent are two axes, three levels each** (`levels.py`). They were one
+blank page — `preferences.md` — and an empty one meant nothing was said, which is not
+neutral: it is the ambitious end, picked by default and discovered afterwards. Whatever
+people wrote in that file was nearly always saying two separable things at once, so the
+useful combinations ("thorough, but check with me before real money") were hard to ask
+for. They live at three scopes: the config file for the usual pair, the two flags for a
+session, `/level` for a change mid-study. Where the free-text note and a level disagree
+the note wins, and the briefing says so — the note is the person's own sentences and
+the level came off a menu. `/status` reports the pair, which is the other half of why
+they are named rather than prose.
 
 **Two keys, two bills.** The workspace key covers compute and capture and is billed to
 the workspace account. The model key covers the model and is billed to you by your

--- a/openreynolds/cli.py
+++ b/openreynolds/cli.py
@@ -22,7 +22,7 @@ from .backend.local import LocalBackend
 from .backend.base import Backend, BackendError, WORKSPACE_ROOT
 from .browse import Browser
 from .capture import Capture
-from . import commands, images, mesher
+from . import commands, images, levels, mesher
 from .config import Config, config_path
 from .delivery import Gallery
 from .llm import PRESETS, ProviderError, make_provider, preset_for
@@ -53,6 +53,18 @@ console = Console()
 @click.option("--study", "study_id", help="Resume a local study by id.")
 @click.option("--instance", "instance_id", help="Use a specific workspace instance.")
 @click.option("--model", help="Override the model for this session.")
+@click.option(
+    "--ambition",
+    type=click.Choice(list(levels.AMBITION), case_sensitive=False),
+    default=None,
+    help="How much work this study is worth (default: standard).",
+)
+@click.option(
+    "--consent",
+    type=click.Choice(list(levels.CONSENT), case_sensitive=False),
+    default=None,
+    help="When to come back and ask (default: costly).",
+)
 @click.option("--no-capture", is_flag=True, help="Do not send anything to the platform.")
 @click.option("--plain", is_flag=True, help="Plain streaming terminal instead of the interface.")
 @click.option(
@@ -73,6 +85,8 @@ def main(
     study_id: str | None,
     instance_id: str | None,
     model: str | None,
+    ambition: str | None,
+    consent: str | None,
     no_capture: bool,
     plain: bool,
     keep_alive: bool,
@@ -85,6 +99,10 @@ def main(
     cfg = Config.load()
     if model:
         cfg.model = model
+    if ambition:
+        cfg.ambition = levels.normalise(ambition, "ambition")
+    if consent:
+        cfg.consent = levels.normalise(consent, "consent")
     if no_capture:
         cfg.capture = False
 
@@ -186,6 +204,17 @@ def config_cmd(from_env: bool, key_file: Path | None, provider: str | None) -> N
                 "Model API key", default=cfg.llm_api_key or "", hide_input=True
             ).strip()
         cfg.model = click.prompt("Model", default=cfg.model).strip()
+        # The two levels are the only settings here that are not credentials, and they
+        # are the ones a person is most likely to want a standing answer to. Asked
+        # last, so the run that only wanted to paste a key can hold enter twice.
+        for axis, current in (("ambition", cfg.ambition), ("consent", cfg.consent)):
+            console.print(f"  ({levels.AXES[axis][current]})")
+            setattr(cfg, axis, click.prompt(
+                axis.capitalize(),
+                default=current,
+                type=click.Choice(list(levels.AXES[axis]), case_sensitive=False),
+                show_choices=True,
+            ).strip().lower())
     except (click.Abort, EOFError):
         # Some shells report a terminal and then deliver EOF, so isatty() alone cannot
         # tell whether prompting will work. Explain rather than dying on "Aborted!".
@@ -377,6 +406,8 @@ def _print_settings(cfg: Config) -> None:
         ("provider", cfg.provider),
         ("model key", "via the service key" if cfg.provider == "reynolds" else _redact(cfg.llm_api_key)),
         ("model", cfg.model),
+        ("ambition", cfg.ambition),
+        ("consent", cfg.consent),
     ):
         console.print(f"  {name:14} {value or '[red]not set[/]'}")
 
@@ -1051,6 +1082,8 @@ def session(
                 interactive=not one_shot,
                 browser=browser,
                 preferences=cfg.preferences,
+                ambition=cfg.ambition,
+                consent=cfg.consent,
             )
         )
         try:
@@ -1292,6 +1325,53 @@ def _when(mtime: float) -> str:
     return time.strftime("%Y-%m-%d %H:%M", time.gmtime(mtime)) + "Z"
 
 
+def _standing_lines(ambition: str, consent: str, preferences: str = "") -> list[str]:
+    """What the user wants: the two levels, and their standing note if they keep one.
+
+    Separate from the rest of the briefing because it is the half a thread has to be
+    told again whenever it starts over. The workspace facts can be re-derived from the
+    workspace; what a person asked for cannot be derived from anything.
+    """
+    # The levels are how much work the study is worth and when the user wants to hear
+    # from you. Named rather than free text so they can be asked for without composing
+    # a note, and so `/status` can say where a session stands.
+    lines = list(levels.briefing_lines(ambition, consent))
+    if preferences:
+        # The user's standing note, in the user's voice. The harness relays it
+        # verbatim and adds nothing: what to do about it stays the model's call,
+        # like anything else the user says.
+        #
+        # Which of the two wins is settled here rather than left to be discovered.
+        # The levels came off a menu; the note is the person's own sentences, and
+        # someone who writes one and picks a level that disagrees with it meant the
+        # sentences. Saying so is a decision; leaving it open would be an accident.
+        lines.append(
+            "The user keeps a standing note that they ask to have passed on at the "
+            "start of every session. Where it and the two levels differ, the note is "
+            "the one they wrote themselves. In their own words:"
+        )
+        lines.append(preferences.strip())
+    return lines
+
+
+def _fresh_thread_brief(store: Store, backend: Backend, cfg: Config) -> str:
+    """The blurb a rebuilt thread opens with, after a context refresh.
+
+    `situation()` describes the workspace, and a refresh empties the thread. Without
+    this the second half of a long study ran on defaults nobody chose: the levels and
+    the standing note were said once at session start and then thrown away at 80% of
+    the window, while `/status` went on reporting levels the thread had never heard
+    of. The workspace survives a refresh on disk; what the user asked for only
+    survives by being said again.
+    """
+    return "\n".join(
+        [
+            situation(store, backend),
+            *_standing_lines(cfg.ambition, cfg.consent, cfg.preferences),
+        ]
+    )
+
+
 def _situation_brief(
     store: Store,
     backend: Backend,
@@ -1299,6 +1379,8 @@ def _situation_brief(
     interactive: bool,
     browser: Browser | None = None,
     preferences: str = "",
+    ambition: str = levels.DEFAULT_AMBITION,
+    consent: str = levels.DEFAULT_CONSENT,
 ) -> str:
     """Facts about this session, assembled by the harness.
 
@@ -1318,15 +1400,7 @@ def _situation_brief(
     machine = _machine_note(backend)
     if machine:
         lines.append(machine)
-    if preferences:
-        # The user's standing note, in the user's voice. The harness relays it
-        # verbatim and adds nothing: what to do about it stays the model's call,
-        # like anything else the user says.
-        lines.append(
-            "The user keeps a standing note that they ask to have passed on at the "
-            "start of every session. In their own words:"
-        )
-        lines.append(preferences.strip())
+    lines.extend(_standing_lines(ambition, consent, preferences))
     if interactive:
         lines.append(
             "A person is at the terminal for this session and can answer you. Anything "
@@ -1547,8 +1621,43 @@ def _apply(
             return None
         loop.say(command.text)
         return command.text
+    if command.kind == commands.LEVEL:
+        said = _level(command.text, loop.cfg, view)
+        if said:
+            loop.say(said)
+        return said
     _local(command, view, browser, store, loop, progress)
     return None
+
+
+def _level(text: str, cfg: Config, view: View) -> str | None:
+    """Show the two levels, or change them for the rest of this study.
+
+    The third scope the levels have. A per-user default in the config file answers
+    "how do I usually work", `--ambition`/`--consent` answer "how about today", and
+    this answers the case the other two cannot: the answer turned out to be more
+    interesting than the question, halfway through. Changing them mid-study reaches
+    the model as the user's own sentence, because that is what it is -- the harness
+    is not deciding anything here, it is carrying a word the person typed.
+
+    Bare `/level` costs no turn, like `/status`: what a study is set to do should be
+    answerable without derailing what it is doing.
+    """
+    ambition, consent, unusable = levels.chosen(text)
+    if unusable or not (ambition or consent):
+        if unusable:
+            # Deliberately not "not a level": one of these can be a perfectly good
+            # level that lost to another word on the same axis, and saying it does not
+            # exist would send someone looking for a typo they did not make.
+            view.info(f"nothing changed, could not use: {', '.join(unusable)}")
+        view.status(levels.menu_lines(cfg.ambition, cfg.consent))
+        return None
+    if ambition:
+        cfg.ambition = ambition
+    if consent:
+        cfg.consent = consent
+    view.status([f"ambition {cfg.ambition}, consent {cfg.consent}"])
+    return levels.spoken(ambition, consent)
 
 
 def _local(
@@ -1574,6 +1683,7 @@ def _local(
                 stage=stage,
                 tokens=getattr(loop, "context_tokens", 0) or 0,
                 token_totals=getattr(loop, "token_totals", None),
+                levels=(loop.cfg.ambition, loop.cfg.consent) if loop is not None else None,
                 local_files=len(browser.local()),
                 sync_age=browser.cache_age(),
             )
@@ -1624,6 +1734,10 @@ def _typed_while_working(
             for_model.append(command.text)
             if concierge is not None:
                 concierge.ask(command.text)
+        elif command.kind == commands.LEVEL:
+            said = _level(command.text, loop.cfg, view)
+            if said:
+                for_model.append(said)
         else:
             _local(command, view, browser, store, loop, progress)
     return "\n".join(for_model) or None
@@ -1829,7 +1943,7 @@ def _run_interactive(
         else:
             _mirror(browser, view)
         if completed and loop.needs_refresh:
-            loop.refresh(situation(store, backend))
+            loop.refresh(_fresh_thread_brief(store, backend, loop.cfg))
 
 
 def _run_one_shot(
@@ -1881,7 +1995,7 @@ def _run_one_shot(
         if live is not None:
             live.catch_up()
         if loop.needs_refresh:
-            loop.refresh(situation(store, backend))
+            loop.refresh(_fresh_thread_brief(store, backend, loop.cfg))
     return "ok"
 
 

--- a/openreynolds/commands.py
+++ b/openreynolds/commands.py
@@ -16,6 +16,7 @@ from typing import Any
 SAY = "say"
 ASIDE = "aside"
 STATUS = "status"
+LEVEL = "level"
 FILES = "files"
 RENDERS = "renders"
 OPEN = "open"
@@ -26,6 +27,9 @@ HELP_TEXT = """\
   /btw <something>   say it without asking the agent to stop what it is doing
   /btw               what is happening right now, answered here - the agent is not told
   /status            the same thing
+  /level             how far this study goes, and when you get asked
+  /level <word>      change one or both of them: sketch/standard/thorough,
+                     early/costly/never
   /files [path]      look at the workspace
   /renders           open the pictures folder and show the newest
   /open              open this study's folder in the file browser
@@ -46,6 +50,8 @@ _VERBS = {
     "/aside": ASIDE,
     "/status": STATUS,
     "/what": STATUS,
+    "/level": LEVEL,
+    "/levels": LEVEL,
     "/files": FILES,
     "/ls": FILES,
     "/renders": RENDERS,
@@ -97,6 +103,7 @@ def status_lines(
     local_files: int = 0,
     sync_age: float | None = None,
     token_totals: dict | None = None,
+    levels: tuple[str, str] | None = None,
 ) -> list[str]:
     """A picture of the session assembled from what the harness already knows.
 
@@ -107,6 +114,10 @@ def status_lines(
     lines = [f"study {session.study_id} on instance {session.instance_id[:8] or '?'}"]
     if stage:
         lines.append(f"right now: {stage}")
+    if levels:
+        # How far this study goes and when it comes back are settings like any other,
+        # and the reason they are named rather than prose is so this line can exist.
+        lines.append(f"ambition {levels[0]}, consent {levels[1]} (/level)")
     if tokens:
         lines.append(f"thread: {tokens:,} tokens")
     totals = token_totals or {}

--- a/openreynolds/config.py
+++ b/openreynolds/config.py
@@ -12,6 +12,7 @@ import stat
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from .levels import DEFAULT_AMBITION, DEFAULT_CONSENT, normalise as normalise_level
 from .llm.presets import FALLBACK_CONTEXT_WINDOW, preset_for
 
 DEFAULT_FOAMD_URL = "https://api.tryreynolds.com"
@@ -72,6 +73,8 @@ _CONFIG_KEYS = (
     "desk_model",
     "effort",
     "context_window",
+    "ambition",
+    "consent",
 )
 
 
@@ -159,8 +162,23 @@ class Config:
     studies_dir: Path = field(default_factory=lambda: Path.cwd() / "studies")
     preferences: str = ""
     """The standing note from `preferences_path()`, or empty when there is none."""
+    ambition: str = DEFAULT_AMBITION
+    """How much work a study is worth, as one of `levels.AMBITION`.
+
+    This and `consent` are the two things a standing note was nearly always saying at
+    once, split apart so either can be asked for without the other. Unlike the note
+    they come from a fixed menu, which is what lets `/status` and `/level` report where
+    a session stands rather than re-reading prose. `OPENREYNOLDS_AMBITION` overrides,
+    `--ambition` overrides that, and `/level` changes it mid-study."""
+    consent: str = DEFAULT_CONSENT
+    """When to come back and ask, as one of `levels.CONSENT`. `OPENREYNOLDS_CONSENT`,
+    `--consent`, `/level`."""
 
     def __post_init__(self) -> None:
+        # A typo in a config file or an environment variable is not a reason a session
+        # cannot start, and the corrected value is what `config` and `/level` print.
+        self.ambition = normalise_level(self.ambition, "ambition")
+        self.consent = normalise_level(self.consent, "consent")
         preset = preset_for(self.provider)
         # A preset's numbers apply when its endpoint is the one in use; an explicit
         # base URL pointing elsewhere is a vendor the table knows nothing about.
@@ -245,6 +263,8 @@ class Config:
             context_window=int(window) if window else 0,
             model=pick("OPENREYNOLDS_MODEL", "model", preset.model if preset else DEFAULT_MODEL),
             effort=pick("OPENREYNOLDS_EFFORT", "effort", DEFAULT_EFFORT),
+            ambition=pick("OPENREYNOLDS_AMBITION", "ambition", DEFAULT_AMBITION),
+            consent=pick("OPENREYNOLDS_CONSENT", "consent", DEFAULT_CONSENT),
             max_tool_output=int(max_output) if max_output else DEFAULT_MAX_TOOL_OUTPUT,
             llm_timeout_s=float(timeout) if timeout else DEFAULT_LLM_TIMEOUT_S,
             mirror_interval_s=(

--- a/openreynolds/levels.py
+++ b/openreynolds/levels.py
@@ -1,0 +1,183 @@
+"""Two named levels: how far to take a study, and when to come back and ask.
+
+There used to be one control over how ambitious a run is, and it was a blank page.
+`preferences.md` is free text, it is empty by default, and when it is empty nothing is
+said -- so ambition wins. A modest question becomes a refinement family with transient
+runs and animation frames, and the person finds out afterwards. Anything else took
+knowing to write a standing note, and knowing what to put in it.
+
+Whatever people write in that file is nearly always saying two separable things: how
+much work the study is worth, and when to be interrupted. A blob of prose bundles them,
+so the useful combinations are hard to ask for -- "be thorough, but check with me
+before real money" and "just the quick version, don't ask" are both reasonable and
+neither was easy to say. Two axes, three named levels each.
+
+Three, not two: two is a switch, and the middle position is the one most studies
+actually want. Three, not seven: a list nobody understands is worse than a blank page.
+The six names are distinct across both axes, which is what lets `/level thorough never`
+route each word to its own axis without saying which is which.
+
+**These carry intent, not a ceiling.** A spend or wall-clock cap the harness checked
+would be a budget the model must reason about, which `docs/design.md` §1 rules out by
+name, and the CLI has no cost figure to check against anyway -- only the four token
+counts `/status` already reports. So a level says what the work is worth and the model
+decides what that means, exactly as it decides what a standing note means.
+
+The text of each level is written to survive `tests/test_prompt.py`'s imperative
+patterns, because it is relayed into the briefing: it says what the person wants, never
+what the model has to do.
+"""
+
+from __future__ import annotations
+
+AMBITION = {
+    "sketch": (
+        "the quick version -- one mesh, a headline number, and an honest word about "
+        "what it rests on. Refinement families, transient runs and validation are "
+        "more than this question is worth."
+    ),
+    "standard": (
+        "one solid answer to the question as asked, checked as far as that answer "
+        "needs and no further."
+    ),
+    "thorough": (
+        "mesh independence, transient where the physics wants it, and a comparison "
+        "against published data or an independent check. This one is worth real work."
+    ),
+}
+"""How much work the study is worth."""
+
+CONSENT = {
+    "early": (
+        "a word before solver time is spent -- the plan, the mesh, the numbers about "
+        "to run."
+    ),
+    "costly": (
+        "a word before anything expensive -- a long transient, a large mesh, a "
+        "family of runs. The cheap version of a thing does not need the call."
+    ),
+    "never": (
+        "no interruptions; a run that goes the whole way and reports at the end."
+    ),
+}
+"""When to come back and ask. Its own axis rather than folded into ambition, because
+the two really are independent: thorough work that checks in about money and quick
+work that does not are both things people want, and one blob of prose can say neither
+of them cleanly."""
+
+DEFAULT_AMBITION = "standard"
+DEFAULT_CONSENT = "costly"
+"""What an empty `preferences.md` means now.
+
+It used to mean nothing was said, which is not neutral -- it is the ambitious end,
+picked by default and discovered afterwards. A default that is written down is a
+default someone can disagree with."""
+
+AXES = {"ambition": AMBITION, "consent": CONSENT}
+
+
+def normalise(value: str, axis: str) -> str:
+    """A recognised level for `axis`, or that axis's default.
+
+    Anything can end up in a config file or an environment variable, and a typo in
+    `OPENREYNOLDS_AMBITION` should not be a session that fails to start. The effective
+    value is what `openreynolds config` prints and what `/level` shows, so a value that
+    was silently corrected is still visible in one command."""
+    known = AXES[axis]
+    picked = (value or "").strip().lower()
+    if picked in known:
+        return picked
+    return DEFAULT_AMBITION if axis == "ambition" else DEFAULT_CONSENT
+
+
+def axis_of(word: str) -> str | None:
+    """Which axis a bare level name belongs to, or `None` if it is not one.
+
+    The six names are distinct, so `/level thorough never` needs no more grammar
+    than this."""
+    picked = (word or "").strip().lower()
+    for axis, known in AXES.items():
+        if picked in known:
+            return axis
+    return None
+
+
+def chosen(text: str) -> tuple[str, str, list[str]]:
+    """Route the words of `/level thorough never` to their axes.
+
+    Returns the ambition asked for, the consent asked for, and anything that could not
+    be used. A line that is not wholly understood applies none of itself: `/level
+    thorogh never` shows the menu rather than silently changing consent and dropping
+    the part they cared about.
+
+    Two words on the same axis are that same case, not a last-one-wins. `/level
+    standard thorough` is somebody correcting themselves without clearing the line, and
+    quietly taking the second half would leave them looking at a confirmation naming
+    one word out of the two they typed."""
+    words = (text or "").split()
+    picked = {"ambition": "", "consent": ""}
+    unusable = []
+    for word in words:
+        axis = axis_of(word)
+        if axis is None or picked[axis]:
+            unusable.append(word)
+        else:
+            picked[axis] = word.strip().lower()
+    if unusable:
+        return "", "", unusable
+    return picked["ambition"], picked["consent"], []
+
+
+def describe(axis: str, level: str) -> str:
+    """One level as "ambition, `thorough`: mesh independence, ..."."""
+    return f"{axis}, `{level}`: {AXES[axis][level]}"
+
+
+def _opened(text: str) -> str:
+    """Sentence case without touching the rest.
+
+    `str.capitalize()` lowercases everything after the first character, which would
+    turn the level names inside the sentence into something nobody typed."""
+    return text[:1].upper() + text[1:]
+
+
+def briefing_lines(ambition: str, consent: str) -> list[str]:
+    """What the briefing says about the two levels.
+
+    Facts about what the person chose, in the register the standing note is relayed
+    in. What to do about them stays the model's call, which is what keeps this inside
+    the contract -- `tests/test_briefing.py` checks every combination of the two.
+    """
+    return [
+        "The user picked two levels from a menu this tool offers, which is how they "
+        "say how far to take a study and when to hear from you.",
+        _opened(describe("ambition", normalise(ambition, "ambition"))),
+        _opened(describe("consent", normalise(consent, "consent"))),
+    ]
+
+
+def spoken(ambition: str = "", consent: str = "") -> str:
+    """A mid-study change, in the user's own voice.
+
+    `/level thorough` is the person saying what they now want, so it reaches the model
+    the way anything else they type does. The menu text goes along with it because the
+    word on its own is only a label until the thread has seen what it stands for."""
+    picked = []
+    if ambition:
+        picked.append(describe("ambition", ambition))
+    if consent:
+        picked.append(describe("consent", consent))
+    return "Changing what I picked for the rest of this study. " + " ".join(
+        _opened(text) for text in picked
+    )
+
+
+def menu_lines(ambition: str, consent: str) -> list[str]:
+    """The menu and where the session currently stands on it, answered locally."""
+    lines = [f"ambition is {normalise(ambition, 'ambition')}, consent is {normalise(consent, 'consent')}"]
+    for axis, known in AXES.items():
+        lines.append(f"{axis}:")
+        for level, text in known.items():
+            lines.append(f"  {level:9} {text}")
+    lines.append("/level <one or two of those words> changes them for this study")
+    return lines

--- a/openreynolds/tui.py
+++ b/openreynolds/tui.py
@@ -41,7 +41,7 @@ from textual.widgets import (
     Tree,
 )
 
-from . import commands, images
+from . import commands, images, levels
 from .browse import Entry, human
 from .mirror import local_for
 from .progress import BAR_WIDTH, Progress
@@ -403,7 +403,13 @@ class OpenReynoldsApp(App):
             return
         log = self.query_one("#conversation", RichLog)
         command = commands.parse(text)
-        if command.kind in (commands.SAY, commands.ASIDE):
+        # `/level thorough` is the one local verb that also speaks: it changes what the
+        # study is set to do and says so in the thread. A bare `/level` does not, and
+        # neither does a word that is not on the menu.
+        speaks = command.kind in (commands.SAY, commands.ASIDE) or (
+            command.kind == commands.LEVEL and any(levels.chosen(command.text)[:2])
+        )
+        if speaks:
             log.write(f"\n[bold green]you[/bold green]  {_escape(text)}")
         else:
             # It is answered here and never reaches the model; echoing it as speech

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -22,6 +22,7 @@ from conftest import ScriptedReader  # noqa: F401  (keeps conftest importable)
 from openreynolds import cli
 from openreynolds.backend.base import ExecResult, JobStatus
 from openreynolds.browse import Browser
+from openreynolds import levels
 from openreynolds.store import JobRecord
 from test_prompt import IMPERATIVE_PATTERNS
 
@@ -56,6 +57,24 @@ def every_shape_of_briefing(backend, store):
     # A resume re-reads every running job's status, so the backend has to know it too.
     backend.jobs["job-1"] = JobStatus(job_id="job-1", status="running", name="solve")
     yield "resumed with a job running", brief_for(backend, store, resuming=True)
+
+    # Nine combinations of the two levels, and each one is prose the model reads. A
+    # level is the harness saying what the person wants, which is a hair away from the
+    # harness saying what to do, so every one of them goes through the same sweep --
+    # including with a standing note beside them, which is where the sentence about
+    # which of the two wins appears.
+    store.session.jobs.clear()
+    a_workspace(backend)
+    for ambition in levels.AMBITION:
+        for consent in levels.CONSENT:
+            yield (
+                f"{ambition}/{consent}",
+                brief_for(backend, store, ambition=ambition, consent=consent),
+            )
+    yield "levels beside a note", brief_for(
+        backend, store, ambition="thorough", consent="never",
+        preferences="Render the mesh and look at it.",
+    )
 
 
 @pytest.mark.parametrize("pattern", IMPERATIVE_PATTERNS)
@@ -155,6 +174,58 @@ def test_no_note_means_no_mention_of_one(backend, store):
     assert "standing note" not in brief
 
 
+# -- the two levels ---------------------------------------------------------------
+
+
+def test_the_briefing_says_which_levels_the_user_picked(backend, store):
+    """Before this the only control over how ambitious a run is was a blank page, and
+    an empty one meant nothing was said -- which is not neutral. It is the ambitious
+    end, chosen by default and found out about afterwards."""
+    a_workspace(backend)
+
+    brief = brief_for(backend, store, ambition="sketch", consent="never")
+
+    assert "Ambition, `sketch`:" in brief
+    assert "Consent, `never`:" in brief
+    assert levels.AMBITION["sketch"] in brief
+    assert levels.CONSENT["never"] in brief
+
+
+def test_the_levels_are_there_even_when_nobody_set_them(backend, store):
+    """A default that is written down is a default someone can disagree with."""
+    a_workspace(backend)
+
+    brief = brief_for(backend, store)
+
+    assert "Ambition, `standard`:" in brief
+    assert "Consent, `costly`:" in brief
+
+
+def test_a_note_beside_the_levels_is_said_to_be_the_later_word(backend, store):
+    """Which of the two wins when they disagree is a decision, and an undecided one
+    would be discovered by whoever hit it first. The levels come off a menu; the note
+    is the person's own sentences, so the note is what they meant."""
+    a_workspace(backend)
+
+    brief = brief_for(
+        backend, store, ambition="sketch", preferences="Always mesh independence."
+    )
+
+    assert "the note is the one they wrote themselves" in brief
+    assert "Always mesh independence." in brief
+
+
+def test_an_unknown_level_is_shown_as_the_default_rather_than_relayed(backend, store):
+    """A typo in `OPENREYNOLDS_AMBITION` reaching the briefing would put a word in the
+    user's mouth that they never picked and the tool does not understand."""
+    a_workspace(backend)
+
+    brief = brief_for(backend, store, ambition="thorogh")
+
+    assert "thorogh" not in brief
+    assert "Ambition, `standard`:" in brief
+
+
 # -- what the other directories on the volume are ------------------------------
 
 
@@ -208,3 +279,56 @@ def test_a_study_that_owns_the_whole_workspace_is_told_nothing_about_neighbours(
     volume_with(backend)
     brief = brief_for(backend, store)
     assert "earlier sessions" not in brief
+
+
+# -- what survives a context refresh ----------------------------------------------
+
+
+def refreshed(backend, store, **settings):
+    from openreynolds.config import Config
+
+    return cli._fresh_thread_brief(store, backend, Config(**settings))
+
+
+def test_a_refreshed_thread_is_told_the_levels_again(backend, store):
+    """A refresh empties the thread, so the second half of a long study used to run on
+    defaults nobody chose: the levels were said once at session start and thrown away
+    at 80% of the window, while `/status` went on reporting them from the config."""
+    a_workspace(backend)
+
+    brief = refreshed(backend, store, ambition="sketch", consent="never")
+
+    assert "Ambition, `sketch`:" in brief
+    assert "Consent, `never`:" in brief
+
+
+def test_a_refreshed_thread_is_told_the_standing_note_again(backend, store):
+    """Same loss, and this one predates the levels: the note was relayed at session
+    start and never again. The workspace survives a refresh on disk; what the user
+    asked for only survives by being said."""
+    a_workspace(backend)
+
+    brief = refreshed(backend, store, preferences="Render the mesh and look at it.")
+
+    assert "Render the mesh and look at it." in brief
+
+
+def test_a_refreshed_thread_still_says_what_the_workspace_is(backend, store):
+    """The facts `situation()` carried are not displaced by the ones added to it."""
+    a_workspace(backend)
+
+    brief = refreshed(backend, store)
+
+    assert "fresh conversation thread" in brief
+
+
+@pytest.mark.parametrize("pattern", IMPERATIVE_PATTERNS)
+def test_the_refreshed_briefing_tells_the_model_nothing_to_do(pattern, backend, store):
+    a_workspace(backend)
+    brief = refreshed(
+        backend, store, ambition="thorough", consent="early",
+        preferences="Check the layer report.",
+    )
+
+    match = re.search(pattern, brief, re.IGNORECASE)
+    assert match is None, f"imperative language in the refreshed briefing: {match!r}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,8 +261,12 @@ def test_config_writes_credentials_outside_the_repo(tmp_path, monkeypatch):
     monkeypatch.delenv("FOAMD_API_KEY", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
+    # Service url, service key, provider, model key, model, then the two levels --
+    # which take their current value on a bare newline.
     result = CliRunner().invoke(
-        cli.main, ["config"], input="https://svc.example/\nof_live_x\nzai\nsk-zai-y\nglm-4.6\n"
+        cli.main,
+        ["config"],
+        input="https://svc.example/\nof_live_x\nzai\nsk-zai-y\nglm-4.6\n\n\n",
     )
 
     assert result.exit_code == 0
@@ -273,6 +277,30 @@ def test_config_writes_credentials_outside_the_repo(tmp_path, monkeypatch):
     assert saved["provider"] == "zai"
     assert saved["llm_api_key"] == "sk-zai-y"
     assert saved["context_window"] == 200_000
+    assert saved["ambition"] == "standard", "held enter, so the default stands"
+    assert saved["consent"] == "costly"
+
+
+def test_config_sets_the_two_levels(tmp_path, monkeypatch):
+    """The README says `openreynolds config` sets your usual pair. It did not ask,
+    which left no supported way to change the per-user default short of editing the
+    JSON by hand or exporting an environment variable for every session."""
+    target = tmp_path / "config.json"
+    monkeypatch.setattr(cli, "_can_prompt", lambda: True)
+    monkeypatch.setenv("OPENREYNOLDS_CONFIG", str(target))
+    for name in ("FOAMD_URL", "FOAMD_API_KEY", "ANTHROPIC_API_KEY",
+                 "OPENREYNOLDS_AMBITION", "OPENREYNOLDS_CONSENT"):
+        monkeypatch.delenv(name, raising=False)
+
+    result = CliRunner().invoke(
+        cli.main,
+        ["config"],
+        input="https://svc.example/\nof_live_x\nzai\nsk-zai-y\nglm-4.6\nthorough\nnever\n",
+    )
+
+    assert result.exit_code == 0
+    saved = json.loads(target.read_text())
+    assert (saved["ambition"], saved["consent"]) == ("thorough", "never")
 
 
 def test_exit_works_while_a_job_is_running(loop, backend, store, view, quiet_console):
@@ -1506,3 +1534,58 @@ def test_recover_session_survives_a_service_without_the_route(store):
     store.session.home = ""
     cli._recover_session(store, _StudyClient(boom=True), "s")
     assert store.session.home == ""                  # unchanged, no exception
+
+
+# -- changing the levels mid-study ---------------------------------------------
+
+
+def test_a_level_change_reaches_the_model_and_sticks(loop, view):
+    """The third scope the levels have, and the only one that answers the case the
+    other two cannot: the answer turned out to be more interesting than the question,
+    halfway through."""
+    said = cli._level("thorough never", loop.cfg, view)
+
+    assert (loop.cfg.ambition, loop.cfg.consent) == ("thorough", "never")
+    assert said and "`thorough`" in said and "`never`" in said
+
+
+def test_one_word_leaves_the_other_axis_alone(loop, view):
+    loop.cfg.ambition = "sketch"
+    loop.cfg.consent = "early"
+
+    cli._level("thorough", loop.cfg, view)
+
+    assert (loop.cfg.ambition, loop.cfg.consent) == ("thorough", "early")
+
+
+def test_a_bare_level_shows_the_menu_and_says_nothing_to_the_model(loop, view):
+    """Like `/status`: what a study is set to do should be answerable without
+    derailing what it is doing."""
+    said = cli._level("", loop.cfg, view)
+
+    assert said is None
+    assert any("ambition is standard" in line for line in view.statuses[-1])
+
+
+def test_a_misspelt_level_changes_nothing_and_says_which_word(loop, view):
+    """Half-applying `/level thorogh never` would set consent, silently drop the word
+    they cared about, and leave them believing both had taken."""
+    said = cli._level("thorogh never", loop.cfg, view)
+
+    assert said is None
+    assert (loop.cfg.ambition, loop.cfg.consent) == ("standard", "costly")
+    assert any("thorogh" in line for line in view.infos)
+
+
+def test_a_level_typed_at_the_prompt_goes_into_the_thread(
+    loop, backend, store, view, quiet_console
+):
+    install_model(loop, [message([text_block("noted")])])
+
+    cli._run_interactive(
+        loop, backend, store, view, Browser(backend, store),
+        ScriptedReader(["/level thorough", "/exit"]),
+    )
+
+    assert loop.cfg.ambition == "thorough"
+    assert "`thorough`" in loop.messages[0]["content"]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import pytest
 
 from openreynolds import commands
-from openreynolds.commands import ASIDE, EXIT, FILES, HELP, OPEN, SAY, STATUS, parse
+from openreynolds.commands import (
+    ASIDE, EXIT, FILES, HELP, LEVEL, OPEN, SAY, STATUS, parse,
+)
 
 
 @pytest.mark.parametrize(
@@ -17,6 +19,9 @@ from openreynolds.commands import ASIDE, EXIT, FILES, HELP, OPEN, SAY, STATUS, p
         ("/bytheway hello", ASIDE),
         ("/btw", STATUS),
         ("/status", STATUS),
+        ("/level", LEVEL),
+        ("/level thorough", LEVEL),
+        ("/levels", LEVEL),
         ("/files", FILES),
         ("/ls /work/case", FILES),
         ("/open", OPEN),
@@ -87,8 +92,24 @@ def test_status_names_the_last_job_once_it_has_finished(store):
 
 def test_the_help_lists_every_verb_it_accepts():
     """A command nobody can discover is a command nobody uses."""
-    for verb in ("/btw", "/status", "/files", "/open", "/help", "/exit"):
+    for verb in ("/btw", "/status", "/level", "/files", "/open", "/help", "/exit"):
         assert verb in commands.HELP_TEXT
+
+
+def test_a_level_carries_the_words_that_follow_it():
+    assert commands.parse("/level thorough never").text == "thorough never"
+
+
+def test_status_says_where_the_study_stands_on_the_two_levels(store):
+    """The reason to name these rather than leave them in prose is so this line can
+    exist: a person can ask how far the run is meant to go without spending a turn."""
+    joined = "\n".join(commands.status_lines(store, levels=("thorough", "never")))
+
+    assert "ambition thorough, consent never" in joined
+
+
+def test_status_leaves_the_levels_out_when_it_was_not_told_them(store):
+    assert "ambition" not in "\n".join(commands.status_lines(store))
 
 
 def test_renders_verbs_parse():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,8 @@ ENV_KEYS = (
     "OPENREYNOLDS_NARRATE_EVERY_S",
     "OPENREYNOLDS_CAPTURE",
     "OPENREYNOLDS_DESK",
+    "OPENREYNOLDS_AMBITION",
+    "OPENREYNOLDS_CONSENT",
 )
 
 
@@ -111,6 +113,41 @@ def test_no_preferences_file_means_an_empty_note(clean_env):
     assert Config.load().preferences == ""
 
 
+# -- the two levels ------------------------------------------------------------
+
+
+def test_the_levels_have_defaults_of_their_own(clean_env):
+    """An empty note used to mean nothing was said about how far to take a study,
+    and nothing said is the ambitious end by default."""
+    cfg = Config.load()
+    assert cfg.ambition == "standard"
+    assert cfg.consent == "costly"
+
+
+def test_the_file_and_the_environment_both_set_the_levels(clean_env, monkeypatch):
+    write_config(clean_env, ambition="sketch", consent="never")
+    assert (Config.load().ambition, Config.load().consent) == ("sketch", "never")
+
+    monkeypatch.setenv("OPENREYNOLDS_AMBITION", "thorough")
+    monkeypatch.setenv("OPENREYNOLDS_CONSENT", "early")
+    assert (Config.load().ambition, Config.load().consent) == ("thorough", "early")
+
+
+@pytest.mark.parametrize("bad", ["thorogh", "", "  ", "AGGRESSIVE"])
+def test_a_level_nobody_recognises_falls_back_rather_than_failing(clean_env, bad):
+    """A typo in an environment variable should not be a session that will not start,
+    and it must not reach the briefing either -- that would put a word in the user's
+    mouth that they never picked."""
+    write_config(clean_env, ambition=bad)
+    assert Config.load().ambition == "standard"
+
+
+def test_a_level_is_read_case_insensitively(clean_env):
+    write_config(clean_env, ambition="Thorough", consent="NEVER")
+    cfg = Config.load()
+    assert (cfg.ambition, cfg.consent) == ("thorough", "never")
+
+
 # -- what counts as configured -------------------------------------------------
 
 
@@ -150,6 +187,8 @@ def test_save_writes_only_the_settings_that_have_values(clean_env):
         "desk_model": "claude-haiku-4-5",
         "effort": "high",
         "context_window": 1_000_000,
+        "ambition": "standard",
+        "consent": "costly",
     }
     assert "studies_dir" not in saved
     assert "capture" not in saved

--- a/tests/test_levels.py
+++ b/tests/test_levels.py
@@ -1,0 +1,155 @@
+"""The two axes, and the words that name them.
+
+The whole point of naming these rather than leaving them to `preferences.md` is that a
+named thing can be checked, reported and changed. So the tests are about the menu
+holding its shape -- distinct names, no imperative prose, a safe answer for a word
+nobody recognises -- rather than about what a level makes the model do, which is the
+model's business and always was.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from openreynolds import levels
+from test_prompt import IMPERATIVE_PATTERNS
+
+
+def test_the_two_axes_have_three_levels_each():
+    """Two is a switch and the middle position is what most studies want; a longer
+    list is a menu nobody reads."""
+    assert len(levels.AMBITION) == 3
+    assert len(levels.CONSENT) == 3
+
+
+def test_no_level_name_belongs_to_both_axes():
+    """`/level thorough never` routes each word by name alone. A name on both axes
+    would make that ambiguous, and the ambiguity would be silent."""
+    assert not set(levels.AMBITION) & set(levels.CONSENT)
+
+
+@pytest.mark.parametrize("pattern", IMPERATIVE_PATTERNS)
+@pytest.mark.parametrize(
+    "text", [*levels.AMBITION.values(), *levels.CONSENT.values()], ids=lambda t: t[:24]
+)
+def test_no_level_tells_the_model_what_to_do(pattern, text):
+    """Every one of these is relayed into the briefing, so it lives under the same
+    rule as the briefing does: it says what the person wants, not what to do."""
+    match = re.search(pattern, text, re.IGNORECASE)
+    assert match is None, f"imperative language in a level: {match!r}"
+
+
+def test_the_defaults_are_on_the_menu():
+    assert levels.DEFAULT_AMBITION in levels.AMBITION
+    assert levels.DEFAULT_CONSENT in levels.CONSENT
+
+
+# -- reading a value nobody checked --------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["thorogh", "", "   ", "yes", "high"])
+def test_an_unrecognised_value_becomes_the_default(value):
+    assert levels.normalise(value, "ambition") == levels.DEFAULT_AMBITION
+    assert levels.normalise(value, "consent") == levels.DEFAULT_CONSENT
+
+
+@pytest.mark.parametrize("value", ["Thorough", " THOROUGH ", "thorough"])
+def test_a_level_is_recognised_however_it_was_typed(value):
+    assert levels.normalise(value, "ambition") == "thorough"
+
+
+def test_axis_of_names_the_axis_or_nothing():
+    assert levels.axis_of("sketch") == "ambition"
+    assert levels.axis_of("never") == "consent"
+    assert levels.axis_of("sideways") is None
+
+
+# -- what `/level <words>` means -----------------------------------------------
+
+
+def test_one_word_changes_one_axis():
+    assert levels.chosen("thorough") == ("thorough", "", [])
+    assert levels.chosen("never") == ("", "never", [])
+
+
+def test_two_words_change_both_in_either_order():
+    assert levels.chosen("thorough never") == ("thorough", "never", [])
+    assert levels.chosen("never thorough") == ("thorough", "never", [])
+
+
+def test_nothing_typed_changes_nothing():
+    assert levels.chosen("") == ("", "", [])
+
+
+def test_a_word_nobody_recognises_changes_neither_axis():
+    """`/level thorogh never` half-applied would set consent, drop the word they
+    cared about, and say nothing about it. Both stay put and the menu comes back."""
+    assert levels.chosen("thorogh never") == ("", "", ["thorogh"])
+
+
+# -- the prose each of them produces -------------------------------------------
+
+
+def test_the_briefing_names_both_levels_and_says_what_they_mean():
+    lines = levels.briefing_lines("sketch", "never")
+
+    assert "Ambition, `sketch`:" in lines[1]
+    assert levels.AMBITION["sketch"] in lines[1]
+    assert "Consent, `never`:" in lines[2]
+    assert levels.CONSENT["never"] in lines[2]
+
+
+def test_the_briefing_lines_survive_a_value_from_a_stale_config():
+    lines = "\n".join(levels.briefing_lines("aggressive", "sometimes"))
+
+    assert "aggressive" not in lines and "sometimes" not in lines
+    assert "`standard`" in lines and "`costly`" in lines
+
+
+def test_a_mid_study_change_is_a_sentence_in_the_first_person():
+    """It reaches the model the way anything else the user types does, because that
+    is what it is: they typed it."""
+    said = levels.spoken(ambition="thorough")
+
+    assert said.startswith("Changing what I picked")
+    assert "`thorough`" in said
+    assert levels.AMBITION["thorough"] in said
+
+
+def test_a_change_to_one_axis_says_nothing_about_the_other():
+    said = levels.spoken(consent="never").lower()
+
+    assert "consent" in said
+    assert "ambition" not in said
+
+
+def test_the_menu_shows_where_the_session_currently_stands():
+    lines = "\n".join(levels.menu_lines("sketch", "early"))
+
+    assert "ambition is sketch, consent is early" in lines
+    for name in (*levels.AMBITION, *levels.CONSENT):
+        assert name in lines
+
+
+def test_capitalising_a_line_leaves_the_level_name_alone():
+    """`str.capitalize()` lowercases the rest of the string, which would rewrite the
+    level names inside the sentence into words nobody typed."""
+    line = levels.briefing_lines("thorough", "never")[1]
+
+    assert "`thorough`" in line
+    assert line.startswith("Ambition")
+
+
+def test_two_words_on_one_axis_apply_neither():
+    """`/level standard thorough` is somebody correcting themselves without clearing
+    the line. Taking the second quietly would show them a confirmation naming one word
+    out of the two they typed, which is the half-application this refuses everywhere
+    else."""
+    assert levels.chosen("standard thorough") == ("", "", ["thorough"])
+    assert levels.chosen("never early") == ("", "", ["early"])
+
+
+def test_one_word_per_axis_is_still_fine():
+    assert levels.chosen("sketch never") == ("sketch", "never", [])

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -131,6 +131,38 @@ async def test_typing_reaches_the_session_and_is_echoed():
     assert app.typed.get_nowait() == "that looks wrong"
 
 
+def _echoed(app) -> list[str]:
+    """What the conversation pane was told, as plain strings."""
+    from textual.widgets import RichLog
+
+    log = app.query_one("#conversation", RichLog)
+    return [str(getattr(line, "text", line)) for line in log.lines]
+
+
+async def test_a_level_change_is_echoed_as_speech_and_a_bare_one_is_not():
+    """The dim echo means "answered here, the agent was not told". `/level thorough`
+    does reach the model -- it changes what the study is set to do and says so in the
+    thread -- so echoing it dimly would claim the opposite. A bare `/level` is a
+    question answered locally, like `/status`, and stays dim."""
+    app = idle_app()
+    async with running(app) as pilot:
+        await pilot.click("#prompt")
+        await pilot.press(*"/level thorough")
+        await pilot.press("enter")
+        await pilot.pause()
+        spoken = " ".join(_echoed(app))
+
+        await pilot.press(*"/level")
+        await pilot.press("enter")
+        await pilot.pause()
+        both = " ".join(_echoed(app))
+
+    assert app.typed.get_nowait() == "/level thorough"
+    assert app.typed.get_nowait() == "/level"
+    assert "you" in spoken, "a level change is the user speaking"
+    assert both.count("you") == 1, "a bare /level is answered here, not said"
+
+
 async def test_an_empty_line_is_not_a_turn():
     app = idle_app()
     async with running(app) as pilot:


### PR DESCRIPTION
Closes #25.

The issue asks for named levels in the agent itself, and leaves five questions open before code. This settles all five and implements them.

## Two axes, three levels each

`levels.py` is the whole vocabulary; nothing else in the package knows what a level *means*.

| `--ambition` | how much work the study is worth |
| --- | --- |
| `sketch` | one mesh, a headline number, and an honest word about what it rests on |
| `standard` | **(default)** one solid answer to the question as asked, checked as far as that answer needs |
| `thorough` | mesh independence, transient where the physics wants it, a comparison against published data |

| `--consent` | when to come back and ask |
| --- | --- |
| `early` | a word before solver time is spent at all |
| `costly` | **(default)** a word before anything expensive — a long transient, a large mesh, a family of runs |
| `never` | no interruptions; a run that goes the whole way and reports at the end |

## The five open questions

**What the levels are, and how many.** Three each. Two is a switch, and the middle position is what most studies want; a longer list is a menu nobody reads. The six names are distinct across the axes, which is what lets `/level thorough never` route each word without saying which is which.

**Is consent its own axis.** Separate, as the issue suspects. That is the point of the change — `--ambition thorough --consent never` and `--ambition sketch --consent early` are each one line, and neither was sayable before.

**Ceiling or only intent.** *Intent only*, and this one is a real constraint rather than a shrug. A spend or wall-clock cap the harness could check itself is exactly the "budget the model must reason about" that `docs/design.md` §1 rules out by name — a level that stops the agent is the harness enforcing something. There is also no cost figure locally to check against: `loop.token_totals` has the four token counts `/status` already reports and nothing in currency. §1 gained a paragraph saying so, so the next person to want a ceiling finds the reasoning rather than the absence.

**What happens when a note contradicts the level.** The note wins, and the briefing says so in the sentence that introduces it: *"Where it and the two levels differ, the note is the one they wrote themselves."* The levels came off a menu; the note is the person's own sentences. A decision, not something discovered by whoever hit it first.

**Per-user or per-study, and can it change mid-study.** All three scopes, each overriding the last:

- `openreynolds config` and `OPENREYNOLDS_AMBITION` / `OPENREYNOLDS_CONSENT` — the usual pair
- `--ambition` / `--consent` — this session
- `/level thorough never` — mid-study, for when the answer turns out to be more interesting than the question

`/level` alone shows the menu and `/status` reports the pair, neither costing a turn. That is the other half of why these are named values and not more prose: the level is something the session can report against, which is what the issue asks for.

## Staying inside the contract

A level is the harness relaying what a person picked, in the same class as "someone is at the terminal". It is not checked, enforced or graded, and what to do about it stays the model's call.

- `test_briefing.py` now sweeps all nine level combinations, plus one with a standing note beside them, through `IMPERATIVE_PATTERNS` — the same sweep every other shape of the briefing gets.
- `test_levels.py` runs those patterns over each level's text directly, since that text is what reaches the model.
- The system prompt is untouched. `preferences.md` is untouched and still relayed verbatim.

## One fix that came out of this

`Loop.refresh` empties the thread and re-opens it with `watch.situation()`, which describes the workspace and nothing about the person. **`preferences.md` was already being lost this way** — relayed once at session start, thrown away at 80% of the window, so the second half of every long study ran without the standing note its first half had. The new levels would have gone the same way while `/status` kept reporting them from the config, which is how it surfaced. `cli._fresh_thread_brief` now carries both, and goes through the imperative sweep too.

## Two things worth a maintainer's eye

**The default pair is a behaviour change.** Anyone upgrading gets a more restrained agent than they had: `standard`/`costly` instead of nothing-said. That is the fix the issue asks for — a default that is written down is one somebody can disagree with — but it is a change people will notice, not a pure addition.

**`consent` is saved like every other setting, which means an env override can become permanent.** `OPENREYNOLDS_CONSENT=never openreynolds login` writes it into `config.json` for good. `model`, `effort` and `desk_model` have always behaved this way, so I kept it consistent rather than making `consent` the one exception — and `config` now prompts for the pair and `_print_settings` echoes it after every save, so the value is visible when it is written. Happy to drop the two keys from `_CONFIG_KEYS` if you would rather it never persisted from the environment; it is a one-line change.

## Tests

**1983 passed, 18 skipped**, hook-run on the full suite at commit time. New: `test_levels.py`, plus additions to `test_briefing.py`, `test_cli.py`, `test_commands.py`, `test_config.py`, `test_tui.py`. One existing test changed shape — `test_save_writes_only_the_settings_that_have_values` expects the two new keys — and the scripted `config` test gained two newlines for the two new prompts.

Each new guard was checked by reverting its fix and confirming it goes red, rather than trusting that it would.

@ka-bear — flagging you since this is your issue and the design questions were yours to settle; happy to change any of the five answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Wnv8hk7t6Jvakjyn8NVNr
